### PR TITLE
feat: add camera entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,22 +53,9 @@ device id, token, user id and authentication code can be retrieved using the Pro
 
 ![map](./doc/map.png)
 
-### Configuration
-
-The vacuum cleaning map can be displayed on lovelace-ui (it will be displayed only after the first vacuum clean process).
-
-to work you should add a camera entity.
-
-``` yaml
-camera:
-  - platform: local_file
-    name: vacuum_map
-    file_path: "/tmp/proscenic_vacuum_map.svg"
-```
-
-You can use this camera on lovelace to show the map.
-
-The default path to generate the map is `/tmp/proscenic_vacuum_map.svg`. You can define another using the option on Integration menu.
+The camera entity will be automaticaly added.
+The map is stored on your file system, the path is `/tmp/proscenic_vacuum_map.svg`.
+The path can be updated on the integration options.
 
 ## Available attributes
 

--- a/custom_components/proscenic/__init__.py
+++ b/custom_components/proscenic/__init__.py
@@ -10,4 +10,7 @@ async def async_setup_entry(hass, entry):
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, 'vacuum')
     )
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, 'camera')
+    )
     return True

--- a/custom_components/proscenic/camera.py
+++ b/custom_components/proscenic/camera.py
@@ -1,0 +1,34 @@
+"""Support for proscenic 790T Vaccum map."""
+import logging
+
+from .const import DOMAIN, CONF_MAP_PATH, DEFAULT_CONF_MAP_PATH, CONF_DEVICE_ID
+from homeassistant.components.local_file.camera import LocalFile
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the 790T vacuums map camera."""
+    config = hass.data[DOMAIN][config_entry.entry_id]
+    conf_map_path = config[CONF_MAP_PATH] if CONF_MAP_PATH in config else DEFAULT_CONF_MAP_PATH
+    device_id = config[CONF_DEVICE_ID]
+
+    _LOGGER.debug("Adding 790T Vacuums camera to Home Assistant")
+    async_add_entities([ProscenicMapCamera(device_id, conf_map_path)], update_before_add = False)
+
+
+class ProscenicMapCamera(LocalFile):
+    """Representation of a proscenic vacuum map camera."""
+
+    def __init__(self, device_id, file_path):
+        super().__init__(device_id + '_map', file_path)
+        self.device_id = device_id
+
+    @property
+    def unique_id(self) -> str:
+        """Return an unique ID."""
+        return "camera" + self.device_id
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {"identifiers": {(DOMAIN, self.device_id)}}

--- a/custom_components/proscenic/manifest.json
+++ b/custom_components/proscenic/manifest.json
@@ -4,7 +4,9 @@
     "version": "0.0.6",
     "documentation": "https://github.com/deblockt/hass-proscenic-790T-vacuum",
     "issue_tracker": "https://github.com/deblockt/hass-proscenic-790T-vacuum/issues",
-    "dependencies": [],
+    "dependencies": [
+        "local_file"
+    ],
     "codeowners": [
         "@deblockt"
     ],

--- a/custom_components/proscenic/vacuum.py
+++ b/custom_components/proscenic/vacuum.py
@@ -72,8 +72,7 @@ WORK_STATE_TO_STATE = {
 }
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Test"""
-    _LOGGER.info("setup entry " + str(hass.data[DOMAIN][config_entry.entry_id]))
+    """Set up the 790T vacuums."""
     config = hass.data[DOMAIN][config_entry.entry_id]
     conf_sleep = config[CONF_SLEEP] if CONF_SLEEP in config else DEFAULT_CONF_SLEEP
     conf_map_path = config[CONF_MAP_PATH] if CONF_MAP_PATH in config else DEFAULT_CONF_MAP_PATH
@@ -96,7 +95,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the 790T vacuums."""
-    _LOGGER.info("setup platform ")
     _LOGGER.warn("Proscenic vacuum integration yaml configuration is now deprecated. You should configure the integration using the UI.")
     auth = {
         CONF_DEVICE_ID: config[CONF_DEVICE_ID],
@@ -135,12 +133,16 @@ class ProscenicVacuum(VacuumEntity):
     @property
     def unique_id(self) -> str:
         """Return an unique ID."""
-        return self.device.device_id
+        return "vacuum" + self.device.device_id
 
     @property
     def device_info(self):
         """Return the device info."""
-        return {"identifiers": {(DOMAIN, self.device.device_id)}}
+        return {
+            "identifiers": {(DOMAIN, self.device.device_id)},
+            "name": "Proscenic vacuum",
+            "manufacturer": "Proscenic"
+        }
 
     @property
     def is_on(self):


### PR DESCRIPTION
manage the vacuum map with a camera entity. 
a camara entity `camera.<deviceId>_map` is created and display the last cleaning map